### PR TITLE
use Australian Debian mirror

### DIFF
--- a/2.7/debian/8/Dockerfile
+++ b/2.7/debian/8/Dockerfile
@@ -4,6 +4,8 @@ MAINTAINER https://github.com/muccg
 ENV VIRTUAL_ENV /env
 ENV PYTHON_PIP_VERSION 8.1.2
 
+RUN sed -i s/httpredir.debian.org/ftp.au.debian.org/ /etc/apt/sources.list
+
 # create a virtual env in $VIRTUAL_ENV and ensure it respects pip version
 RUN pip install $PIP_OPTS virtualenv \
     && virtualenv $VIRTUAL_ENV \

--- a/3.4/debian/8/Dockerfile
+++ b/3.4/debian/8/Dockerfile
@@ -5,6 +5,8 @@ MAINTAINER https://github.com/muccg
 ENV VIRTUAL_ENV /env
 ENV PYTHON_PIP_VERSION 8.1.2
 
+RUN sed -i s/httpredir.debian.org/ftp.au.debian.org/ /etc/apt/sources.list
+
 # create a virtual env in $VIRTUAL_ENV and ensure it respects pip version
 RUN pyvenv $VIRTUAL_ENV \
     && $VIRTUAL_ENV/bin/pip install --upgrade --no-cache-dir pip==$PYTHON_PIP_VERSION

--- a/3.5/debian/8/Dockerfile
+++ b/3.5/debian/8/Dockerfile
@@ -5,6 +5,8 @@ MAINTAINER https://github.com/muccg
 ENV VIRTUAL_ENV /env
 ENV PYTHON_PIP_VERSION 8.1.2
 
+RUN sed -i s/httpredir.debian.org/ftp.au.debian.org/ /etc/apt/sources.list
+
 # create a virtual env in $VIRTUAL_ENV and ensure it respects pip version
 RUN pyvenv $VIRTUAL_ENV \
     && $VIRTUAL_ENV/bin/pip install --upgrade --no-cache-dir pip==$PYTHON_PIP_VERSION


### PR DESCRIPTION
httpredir.debian.org fails for me roughly one run in four when
doing local dev, which gets quite frustrating. ftp.au.debian.org
goes through to the WAIX mirror when accessed from Murdoch, seems
solid.
